### PR TITLE
Optional document length parsing support

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
@@ -38,13 +38,24 @@ public class BsonFactory extends JsonFactory {
 	 * The BSON generator features enabled by default
 	 */
 	private static final int DEFAULT_BSON_GENERATOR_FEATURE_FLAGS = 0;
-	
+
+	/**
+	 * The BSON parser features enabled by default
+	 */
+	private static final int DEFAULT_BSON_PARSER_FEATURE_FLAGS = 0;
+
 	/**
 	 * The BSON generator features to be enabled when a new
 	 * generator is created
 	 */
 	protected int _bsonGeneratorFeatures = DEFAULT_BSON_GENERATOR_FEATURE_FLAGS;
-	
+
+	/**
+	 * The BSON parser features to be enabled when a new parser
+	 * is created
+	 */
+	protected int _bsonParserFeatures = DEFAULT_BSON_PARSER_FEATURE_FLAGS;
+
 	/**
 	 * @see JsonFactory#JsonFactory()
 	 */
@@ -98,8 +109,51 @@ public class BsonFactory extends JsonFactory {
     public final boolean isEnabled(BsonGenerator.Feature f) {
     	return (_bsonGeneratorFeatures & f.getMask()) != 0;
     }
-    
-    @Override
+
+	/**
+	 * Method for enabling/disabling specified parser features
+	 * (check {@link BsonParser.Feature} for list of features)
+	 *
+	 * @param f	 the feature to enable or disable
+	 * @param state true if the feature should be enabled, false otherwise
+	 */
+	public final BsonFactory configure(BsonParser.Feature f, boolean state) {
+		if (state) {
+			return enable(f);
+		}
+		return disable(f);
+	}
+
+	/**
+	 * Method for enabling specified parser features
+	 * (check {@link BsonParser.Feature} for list of features)
+	 *
+	 * @param f the feature to enable
+	 */
+	public BsonFactory enable(BsonParser.Feature f) {
+		_bsonParserFeatures |= f.getMask();
+		return this;
+	}
+
+	/**
+	 * Method for disabling specified parser features
+	 * (check {@link BsonParser.Feature} for list of features)
+	 *
+	 * @param f the feature to disable
+	 */
+	public BsonFactory disable(BsonParser.Feature f) {
+		_bsonParserFeatures &= ~f.getMask();
+		return this;
+	}
+
+	/**
+	 * @return true if the specified parser feature is enabled
+	 */
+	public final boolean isEnabled(BsonParser.Feature f) {
+		return (_bsonParserFeatures & f.getMask()) != 0;
+	}
+
+	@Override
     public BsonGenerator createJsonGenerator(OutputStream out, JsonEncoding enc)
     	throws IOException {
     	return createJsonGenerator(out);
@@ -116,7 +170,7 @@ public class BsonFactory extends JsonFactory {
     
     @Override
     public BsonParser createJsonParser(InputStream in) throws IOException {
-    	BsonParser p = new BsonParser(_parserFeatures, in);
+    	BsonParser p = new BsonParser(_parserFeatures, _bsonParserFeatures, in);
     	ObjectCodec codec = getCodec();
     	if (codec != null) {
     		p.setCodec(codec);

--- a/src/main/java/de/undercouch/bson4jackson/BsonParser.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonParser.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayDeque;
 import java.util.Date;
 import java.util.Deque;
@@ -37,6 +39,7 @@ import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.impl.JsonParserMinimalBase;
 import org.codehaus.jackson.type.TypeReference;
 
+import de.undercouch.bson4jackson.io.BoundedInputStream;
 import de.undercouch.bson4jackson.io.ByteOrderUtil;
 import de.undercouch.bson4jackson.io.CountingInputStream;
 import de.undercouch.bson4jackson.io.LittleEndianInputStream;
@@ -52,6 +55,30 @@ import de.undercouch.bson4jackson.types.Timestamp;
  */
 public class BsonParser extends JsonParserMinimalBase {
 	/**
+	 * Defines toggable features
+	 */
+	public enum Feature {
+		/**
+		 * <p>Honors the document length field when parsing, useful for when
+		 * reading from streams that may contain other content after the
+		 * document that will be read by something else.</p>
+		 */
+		HONOR_DOCUMENT_LENGTH;
+
+		/**
+		 * @return the bit mask that identifies this feature
+		 */
+		public int getMask() {
+			return (1 << ordinal());
+		}
+	}
+
+	/**
+	 * The features for this parser
+	 */
+	private int _bsonFeatures;
+
+	/**
 	 * The input stream to read from
 	 */
 	private LittleEndianInputStream _in;
@@ -60,7 +87,12 @@ public class BsonParser extends JsonParserMinimalBase {
 	 * Counts the number of bytes read from {@link #_in}
 	 */
 	private CountingInputStream _counter;
-	
+
+	/**
+	 * The raw input stream passed in
+	 */
+	private InputStream _rawInputStream;
+
 	/**
 	 * True if the parser has been closed
 	 */
@@ -81,22 +113,40 @@ public class BsonParser extends JsonParserMinimalBase {
 	 * parser state.
 	 */
 	private Deque<Context> _contexts = new ArrayDeque<Context>();
-	
+
 	/**
 	 * Constructs a new parser
+	 *
 	 * @param jsonFeatures bit flag composed of bits that indicate which
-     * {@link org.codehaus.jackson.JsonParser.Feature}s are enabled.
-	 * @param in the input stream to parse. 
+	 *                     {@link org.codehaus.jackson.JsonParser.Feature}s are enabled.
+	 * @param bsonFeatures bit flag composed of bits that indicate which
+	 *                     {@link Feature}s are enabled.
+	 * @param in		 the input stream to parse.
 	 */
-	public BsonParser(int jsonFeatures, InputStream in) {
+	public BsonParser(int jsonFeatures, int bsonFeatures, InputStream in) {
 		super(jsonFeatures);
-		if (!(in instanceof BufferedInputStream)) {
-			in = new StaticBufferedInputStream(in);
+		_bsonFeatures = bsonFeatures;
+		_rawInputStream = in;
+		// Only initialise streams here if document length isn't going to be honoured
+		if (!isEnabled(Feature.HONOR_DOCUMENT_LENGTH)) {
+			if (!(in instanceof BufferedInputStream)) {
+				in = new StaticBufferedInputStream(in);
+			}
+			_counter = new CountingInputStream(in);
+			_in = new LittleEndianInputStream(_counter);
 		}
-		_counter = new CountingInputStream(in);
-		_in = new LittleEndianInputStream(_counter);
 	}
-	
+
+	/**
+	 * Checks if a generator feature is enabled
+	 *
+	 * @param f the feature
+	 * @return true if the given feature is enabled
+	 */
+	protected boolean isEnabled(Feature f) {
+		return (_bsonFeatures & f.getMask()) != 0;
+	}
+
 	@Override
 	public ObjectCodec getCodec() {
 		return _codec;
@@ -109,7 +159,7 @@ public class BsonParser extends JsonParserMinimalBase {
 
 	@Override
 	public void close() throws IOException {
-		if (isEnabled(Feature.AUTO_CLOSE_SOURCE)) {
+		if (isEnabled(JsonParser.Feature.AUTO_CLOSE_SOURCE)) {
 			_in.close();
 		}
 		_closed = true;
@@ -278,8 +328,33 @@ public class BsonParser extends JsonParserMinimalBase {
 	 * @throws IOException if an I/O error occurs
 	 */
 	protected JsonToken handleNewDocument(boolean array) throws IOException {
-		//read document header (skip size, we're not interested)
-		_in.readInt();
+		if (_in == null) {
+			// This means honorDocumentLength was passed as true, and we haven't yet started reading.  First read the
+			// first int to find out the length of the document.
+			byte[] buf = new byte[4];
+			int len = 0;
+			while (len < 4) {
+				int l = _rawInputStream.read(buf, len, 4 - len);
+				if (l == -1) {
+					throw new IOException("Not enough bytes for length of document");
+				}
+				len += l;
+			}
+			int documentLength = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN).getInt();
+			// Wrap the input stream by a bounded stream, subtract 4 from the length because the size itself is included
+			// in the length
+			InputStream in = new BoundedInputStream(_rawInputStream, documentLength - 4);
+			// Buffer if the raw input stream is not already buffered
+			if (!(_rawInputStream instanceof BufferedInputStream)) {
+				in = new StaticBufferedInputStream(in);
+			}
+			_counter = new CountingInputStream(in);
+			_in = new LittleEndianInputStream(_counter);
+		} else {
+			//read document header (skip size, we're not interested)
+			_in.readInt();
+		}
+
 		_contexts.push(new Context(array));
 		return (array ? JsonToken.START_ARRAY : JsonToken.START_OBJECT);
 	}

--- a/src/main/java/de/undercouch/bson4jackson/io/BoundedInputStream.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/BoundedInputStream.java
@@ -1,0 +1,83 @@
+package de.undercouch.bson4jackson.io;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Input stream that bounds an underlying input stream to a particular size.  Is not threadsafe.
+ */
+public class BoundedInputStream extends FilterInputStream {
+	private final int size;
+	private int count = 0;
+	private boolean eof = false;
+	private int mark;
+
+	public BoundedInputStream(InputStream in, int size) {
+		super(in);
+		this.size = size;
+	}
+
+	@Override
+	public synchronized int read() throws IOException {
+		if (!eof && count < size) {
+			int read = super.read();
+			if (read == -1) {
+				eof = true;
+			} else {
+				count++;
+			}
+			return read;
+		}
+		return -1;
+	}
+
+	@Override
+	public int read(byte[] b) throws IOException {
+		return read(b, 0, b.length);
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		if (eof || count >= size) {
+			return -1;
+		} else {
+			// Bound length by what's remaining
+			len = Math.min(len, size - count);
+			int read = super.read(b, off, len);
+			if (read == -1) {
+				eof = true;
+			} else {
+				count += len;
+			}
+			return read;
+		}
+	}
+
+	@Override
+	public long skip(long n) throws IOException {
+		n = Math.min(n, size - count);
+		long skipped = super.skip(n);
+		count += skipped;
+		return skipped;
+	}
+
+	@Override
+	public int available() throws IOException {
+		return Math.min(super.available(), size - count);
+	}
+
+	@Override
+	public void mark(int readlimit) {
+		mark = count;
+		super.mark(readlimit);
+	}
+
+	@Override
+	public void reset() throws IOException {
+		if (super.markSupported()) {
+			count = mark;
+		}
+		super.reset();
+	}
+}

--- a/src/test/java/de/undercouch/bson4jackson/io/BoundedInputStreamTest.java
+++ b/src/test/java/de/undercouch/bson4jackson/io/BoundedInputStreamTest.java
@@ -1,0 +1,98 @@
+package de.undercouch.bson4jackson.io;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the bounded input stream
+ */
+public class BoundedInputStreamTest {
+
+	private byte[] bytes = new byte[]{10, 20, 30, 40};
+
+	@Test
+	public void testReadWhenBoundSmaller() throws Exception {
+		ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+		BoundedInputStream is = new BoundedInputStream(bais, 3);
+		assertEquals(10, is.read());
+		assertEquals(20, is.read());
+		assertEquals(30, is.read());
+		assertEquals(-1, is.read());
+		assertEquals(-1, is.read());
+		assertEquals(40, bais.read());
+	}
+
+	@Test
+	public void testReadWhenBoundLarger() throws Exception {
+		ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+		BoundedInputStream is = new BoundedInputStream(bais, 5);
+		assertEquals(10, is.read());
+		assertEquals(20, is.read());
+		assertEquals(30, is.read());
+		assertEquals(40, is.read());
+		assertEquals(-1, is.read());
+		assertEquals(-1, is.read());
+		assertEquals(-1, bais.read());
+	}
+
+	@Test
+	public void testReadLargeBufferWhenBoundSmaller() throws Exception {
+		ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+		BoundedInputStream is = new BoundedInputStream(bais, 3);
+
+		byte[] buf = new byte[10];
+		assertEquals(3, is.read(buf));
+		assertArrayEquals(bytes, buf, 0, 3);
+		assertEquals(-1, is.read(buf));
+		assertEquals(40, bais.read());
+	}
+
+	@Test
+	public void testReadSmallBufferWhenBoundSmaller() throws Exception {
+		ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+		BoundedInputStream is = new BoundedInputStream(bais, 3);
+
+		byte[] buf = new byte[2];
+		assertEquals(2, is.read(buf));
+		assertArrayEquals(bytes, buf, 0, 2);
+		assertEquals(1, is.read(buf));
+		assertArrayEquals(bytes, buf, 2, 1);
+		assertEquals(-1, is.read(buf));
+		assertEquals(40, bais.read());
+	}
+
+	@Test
+	public void testReadLargeBufferWhenBoundLarger() throws Exception {
+		ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+		BoundedInputStream is = new BoundedInputStream(bais, 5);
+
+		byte[] buf = new byte[10];
+		assertEquals(4, is.read(buf));
+		assertArrayEquals(bytes, buf, 0, 4);
+		assertEquals(-1, is.read(buf));
+		assertEquals(-1, bais.read());
+	}
+
+	@Test
+	public void testReadSmallBufferWhenBoundLarger() throws Exception {
+		ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+		BoundedInputStream is = new BoundedInputStream(bais, 5);
+
+		byte[] buf = new byte[2];
+		assertEquals(2, is.read(buf));
+		assertArrayEquals(bytes, buf, 0, 2);
+		assertEquals(2, is.read(buf));
+		assertArrayEquals(bytes, buf, 2, 2);
+		assertEquals(-1, is.read(buf));
+		assertEquals(-1, bais.read());
+	}
+
+	private static void assertArrayEquals(byte[] expected, byte[] actual, int off, int len) {
+		for (int i = 0; i < len; i++) {
+			assertEquals("element [" + i + "] not matching", expected[i + off], actual[i]);
+		}
+	}
+}


### PR DESCRIPTION
I've implemented support for issue #11. Currently bson4jackson, because it uses a BufferedInputStream, reads past the end of the document, which causes problems when reading from a stream that contains more than just the BSON document, such as when reading responses from MongoDB.  This pull request adds a feature (disabled by default) to honour the document length, so that buffering can still be done for good performance.  It does this by wrapping the input stream in a BoundedInputStream, that is bounded by the document length.  The feature can be enabled by calling:

```
bsonFactory.enable(BsonParser.Feature.HONOR_DOCUMENT_LENGTH);
```

I've written thorough unit tests too.
