### PR TITLE
Support proper typed generation of all types that the parser can parse

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/BsonModule.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonModule.java
@@ -1,0 +1,48 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson;
+
+import de.undercouch.bson4jackson.serializers.*;
+import de.undercouch.bson4jackson.types.JavaScript;
+import de.undercouch.bson4jackson.types.ObjectId;
+import de.undercouch.bson4jackson.types.Symbol;
+import de.undercouch.bson4jackson.types.Timestamp;
+import org.codehaus.jackson.Version;
+import org.codehaus.jackson.map.module.SimpleModule;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Module that configures Jackson to be able to correctly handle all BSON types
+ *
+ * @author James Roper
+ * @since 1.3
+ */
+public class BsonModule extends SimpleModule {
+	public BsonModule() {
+		super("BsonModule", new Version(1, 3, 0, ""));
+		addSerializer(UUID.class, new BsonUuidSerializer());
+		addSerializer(Date.class, new BsonDateSerializer());
+		addSerializer(Calendar.class, new BsonCalendarSerializer());
+		addSerializer(ObjectId.class, new BsonObjectIdSerializer());
+		addSerializer(Pattern.class, new BsonRegexSerializer());
+		addSerializer(JavaScript.class, new BsonJavaScriptSerializer());
+		addSerializer(Timestamp.class, new BsonTimestampSerializer());
+		addSerializer(Symbol.class, new BsonSymbolSerializer());
+	}
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonCalendarSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonCalendarSerializer.java
@@ -1,0 +1,39 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson.serializers;
+
+import de.undercouch.bson4jackson.BsonGenerator;
+import org.codehaus.jackson.map.SerializerProvider;
+
+import java.io.IOException;
+import java.util.Calendar;
+
+/**
+ * Serializes calendars as BSON date type objects
+ *
+ * @author James Roper
+ * @since 1.3
+ */
+public class BsonCalendarSerializer extends BsonSerializer<Calendar> {
+	@Override
+	public void serialize(Calendar calendar, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
+			throws IOException {
+		if (calendar == null) {
+			serializerProvider.defaultSerializeNull(bsonGenerator);
+		} else {
+			bsonGenerator.writeDateTime(calendar.getTime());
+		}
+	}
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonDateSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonDateSerializer.java
@@ -1,0 +1,39 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson.serializers;
+
+import de.undercouch.bson4jackson.BsonGenerator;
+import org.codehaus.jackson.map.SerializerProvider;
+
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * Serialiszs dates as BSON date type objects
+ *
+ * @author James Roper
+ * @since 1.3
+ */
+public class BsonDateSerializer extends BsonSerializer<Date> {
+	@Override
+	public void serialize(Date date, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
+			throws IOException {
+		if (date == null) {
+			serializerProvider.defaultSerializeNull(bsonGenerator);
+		} else {
+			bsonGenerator.writeDateTime(date);
+		}
+	}
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonJavascriptSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonJavascriptSerializer.java
@@ -1,0 +1,39 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson.serializers;
+
+import de.undercouch.bson4jackson.BsonGenerator;
+import de.undercouch.bson4jackson.types.JavaScript;
+import org.codehaus.jackson.map.SerializerProvider;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Serializer for JavaScript
+ *
+ * @since 1.3
+ * @author James Roper
+ */
+public class BsonJavaScriptSerializer extends BsonSerializer<JavaScript> {
+	@Override
+	public void serialize(JavaScript javaScript, BsonGenerator bsonGenerator, SerializerProvider serializerProvider) throws IOException {
+		if (javaScript == null) {
+			serializerProvider.defaultSerializeNull(bsonGenerator);
+		} else {
+			bsonGenerator.writeJavaScript(javaScript, serializerProvider);
+		}
+	}
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonObjectIdSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonObjectIdSerializer.java
@@ -1,0 +1,38 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson.serializers;
+
+import de.undercouch.bson4jackson.BsonGenerator;
+import de.undercouch.bson4jackson.types.ObjectId;
+import org.codehaus.jackson.map.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Serializer for ObjectIds
+ *
+ * @author James Roper
+ * @since 1.3
+ */
+public class BsonObjectIdSerializer extends BsonSerializer<ObjectId> {
+	@Override
+	public void serialize(ObjectId objectId, BsonGenerator bsonGenerator, SerializerProvider serializerProvider) throws IOException {
+		if (objectId == null) {
+			serializerProvider.defaultSerializeNull(bsonGenerator);
+		} else {
+			bsonGenerator.writeObjectId(objectId);
+		}
+	}
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonRegexSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonRegexSerializer.java
@@ -1,0 +1,38 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson.serializers;
+
+import de.undercouch.bson4jackson.BsonGenerator;
+import org.codehaus.jackson.map.SerializerProvider;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Serializer for regular expression patterns
+ *
+ * @since 1.3
+ * @author James Roper
+ */
+public class BsonRegexSerializer extends BsonSerializer<Pattern> {
+	@Override
+	public void serialize(Pattern pattern, BsonGenerator bsonGenerator, SerializerProvider serializerProvider) throws IOException {
+		if (pattern == null) {
+			serializerProvider.defaultSerializeNull(bsonGenerator);
+		} else {
+			bsonGenerator.writeRegex(pattern);
+		}
+	}
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonSerializer.java
@@ -1,0 +1,52 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson.serializers;
+
+import de.undercouch.bson4jackson.BsonGenerator;
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Base class for BSON serializers
+ *
+ * @author James Roper
+ */
+public abstract class BsonSerializer<T> extends JsonSerializer<T> {
+	@Override
+	public void serialize(T t, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+		if (!(jsonGenerator instanceof BsonGenerator)) {
+			throw new JsonGenerationException("BsonDateSerializer can " +
+					"only be used with BsonGenerator");
+		}
+		serialize(t, (BsonGenerator) jsonGenerator, serializerProvider);
+	}
+
+	/**
+	 * Serialize the given object using the given BsonGenerator
+	 *
+	 * @param t				  The object to serialize
+	 * @param bsonGenerator	  The generator to serialize to
+	 * @param serializerProvider The serialization provider
+	 * @throws IOException			 If an error occurred writing to the stream
+	 * @throws JsonProcessingException If a JSON error occurred
+	 */
+	public abstract void serialize(T t, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
+			throws IOException, JsonProcessingException;
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonSymbolSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonSymbolSerializer.java
@@ -1,0 +1,39 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson.serializers;
+
+import de.undercouch.bson4jackson.BsonGenerator;
+import de.undercouch.bson4jackson.types.Symbol;
+import org.codehaus.jackson.map.SerializerProvider;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Serializer for BSON Symbols
+ *
+ * @since 1.3
+ * @author James Roper
+ */
+public class BsonSymbolSerializer extends BsonSerializer<Symbol> {
+	@Override
+	public void serialize(Symbol symbol, BsonGenerator bsonGenerator, SerializerProvider serializerProvider) throws IOException {
+		if (symbol == null) {
+			serializerProvider.defaultSerializeNull(bsonGenerator);
+		} else {
+			bsonGenerator.writeSymbol(symbol);
+		}
+	}
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonTimestampSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonTimestampSerializer.java
@@ -1,0 +1,39 @@
+// Copyright 2010-2011 James Roper
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.undercouch.bson4jackson.serializers;
+
+import de.undercouch.bson4jackson.BsonGenerator;
+import de.undercouch.bson4jackson.types.Timestamp;
+import org.codehaus.jackson.map.SerializerProvider;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Serializer for MongoDB Timestamps
+ *
+ * @since 1.3
+ * @author James Roper
+ */
+public class BsonTimestampSerializer extends BsonSerializer<Timestamp> {
+	@Override
+	public void serialize(Timestamp timestamp, BsonGenerator bsonGenerator, SerializerProvider serializerProvider) throws IOException {
+		if (timestamp == null) {
+			serializerProvider.defaultSerializeNull(bsonGenerator);
+		} else {
+			bsonGenerator.writeTimestamp(timestamp);
+		}
+	}
+}

--- a/src/main/java/de/undercouch/bson4jackson/serializers/BsonUuidSerializer.java
+++ b/src/main/java/de/undercouch/bson4jackson/serializers/BsonUuidSerializer.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package de.undercouch.bson4jackson.uuid;
+package de.undercouch.bson4jackson.serializers;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -20,7 +20,6 @@ import java.util.UUID;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonSerializer;
 import org.codehaus.jackson.map.SerializerProvider;
 
 import de.undercouch.bson4jackson.BsonConstants;
@@ -31,16 +30,11 @@ import de.undercouch.bson4jackson.BsonGenerator;
  * only be used in conjunction with the BsonGenerator.
  * @author Ed Anuff
  */
-public class BsonUuidSerializer extends JsonSerializer<UUID> {
+public class BsonUuidSerializer extends BsonSerializer<UUID> {
 	@Override
-	public void serialize(UUID value, JsonGenerator jgen,
-			SerializerProvider provider) throws IOException,
-			JsonProcessingException {
-		if (!(jgen instanceof BsonGenerator)) {
-			throw new JsonGenerationException("BsonUuidSerializer can " +
-					"only be used with BsonGenerator");
-		}
-		((BsonGenerator)jgen).writeBinary(null, BsonConstants.SUBTYPE_UUID,
+	public void serialize(UUID value, BsonGenerator bgen,
+			SerializerProvider provider) throws IOException {
+		bgen.writeBinary(null, BsonConstants.SUBTYPE_UUID,
 				uuidToLittleEndianBytes(value), 0, 16);
 	}
 

--- a/src/main/java/de/undercouch/bson4jackson/uuid/BsonUuidModule.java
+++ b/src/main/java/de/undercouch/bson4jackson/uuid/BsonUuidModule.java
@@ -16,6 +16,7 @@ package de.undercouch.bson4jackson.uuid;
 
 import java.util.UUID;
 
+import de.undercouch.bson4jackson.serializers.BsonUuidSerializer;
 import org.codehaus.jackson.Version;
 import org.codehaus.jackson.map.module.SimpleModule;
 
@@ -24,7 +25,9 @@ import org.codehaus.jackson.map.module.SimpleModule;
  * with the UUID sub-type. Register with an ObjectMapper instance to enable this
  * functionality.
  * @author Ed Anuff
+ * @deprecated Use {@link de.undercouch.bson4jackson.BsonModule} instead to get all the custom serializers BSON requires
  */
+@Deprecated
 public class BsonUuidModule extends SimpleModule {
 	/**
 	 * Default constructor


### PR DESCRIPTION
Up until now the Mongo Jackson Mapper has only used bson4jackson to parse MongoDB responses, now I tried to see about using it to serialise requests, and found that the serialisation support as far more limited than the deserialisation support.  So, I've implemented serialisation support for all types that bson4jackson knows how to deserialise, including:
- java.util.Date/java.util.Calendar serialised to BSON date time type
- java.util.regex.Pattern serialised to BSON pattern type
- ObjectId serialised to BSON ObjectId type
- Timestamp serialised to BSON Timestamp type
- JavaScript serialised to BSON Javascript(with/without scope) type
- Symbol serialised to BSON symbol type

Also created new BsonModule for registering all BSON serializers, and deprecated BsonUuidModule in favour of using the BsonModule.
