### PR TITLE
Build fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,17 @@ repositories {
     mavenCentral()
 }
 
+tasks.withType(Compile) { 
+    options.compilerArgs << "-Xlint" 
+} 
+
 dependencies {
-    compile 'com.fasterxml.jackson.core:jackson-core:[2.0.0,3.0.0)'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:[2.0.0,3.0.0)'
-    compile 'com.fasterxml.jackson.core:jackson-databind:[2.0.0,3.0.0)'
-    
-    testCompile 'junit:junit:4.10'
-    testCompile 'org.mongodb:mongo-java-driver:2.11.0'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.2.1'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.2.1'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.2.1'
+
+    testCompile 'junit:junit:4.11'
+    testCompile 'org.mongodb:mongo-java-driver:2.11.1'
 }
 
 jar {

--- a/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
@@ -158,22 +158,22 @@ public class BsonFactory extends JsonFactory {
 		throw new UnsupportedOperationException("Can not create writer for non-byte-based target");
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	protected BsonGenerator _createJsonGenerator(Writer out, IOContext ctxt) {
 		return _createGenerator(out, ctxt);
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	protected BsonParser _createJsonParser(byte[] data, int offset, int len, IOContext ctxt) {
         return _createParser(data, offset, len, ctxt);
     }
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	protected BsonParser _createJsonParser(InputStream in, IOContext ctxt) {
         return _createParser(in, ctxt);
     }
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	protected BsonParser _createJsonParser(Reader r, IOContext ctxt) {
         return _createParser(r, ctxt);
     }
@@ -203,7 +203,7 @@ public class BsonFactory extends JsonFactory {
 		return createGenerator(out);
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	protected BsonGenerator _createUTF8JsonGenerator(OutputStream out, IOContext ctxt) throws IOException {
 		return _createUTF8Generator(out, ctxt);
 	}
@@ -250,57 +250,57 @@ public class BsonFactory extends JsonFactory {
 		throw new UnsupportedOperationException("Can not create generator for non-byte-based target");
 	}
 	
-	@Override
+	@Override  @SuppressWarnings("deprecation")
 	public BsonGenerator createJsonGenerator(File f, JsonEncoding enc) throws IOException {
 		return createGenerator(f, enc);
 	}
 	
-	@Override
+	@Override  @SuppressWarnings("deprecation")
 	public BsonGenerator createJsonGenerator(OutputStream out) throws IOException {
 		return createGenerator(out);
 	}
 	
-	@Override
+	@Override  @SuppressWarnings("deprecation")
 	public BsonGenerator createJsonGenerator(OutputStream out, JsonEncoding enc) throws IOException {
 		return createGenerator(out, enc);
 	}
 	
-	@Override
+	@Override  @SuppressWarnings("deprecation")
 	public BsonGenerator createJsonGenerator(Writer out) {
 		return createGenerator(out);
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(byte[] data) throws IOException {
 		return createParser(data);
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(byte[] data, int offset, int len) throws IOException {
 		return createParser(data, offset, len);
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(File f) throws IOException {
 		return createParser(f);
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(InputStream in) throws IOException {
 		return createParser(in);
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(Reader r) {
 		return createParser(r);
 	}
 	
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(String content) {
 		return createParser(content);
 	}
 
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(URL url) throws IOException {
 		return createParser(url);
 	}


### PR DESCRIPTION
Use a specific version of Jackson so that users don't use unstable snapshot version or face unexpected dependency changes. Use junit 4.11 because 4.10 bundles hamcrest in a broken way. Show warnings during compilation and suppress warnings for overriding deprecated APIs.
