### PR TITLE
Feature/issue 44 bson factory copy method support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle/
 build/
+out/
 target/
 reports/
 gradle.properties
@@ -9,3 +10,7 @@ bin/
 .settings/
 .classpath
 .project
+
+*.iml
+*.ipr
+*.iws

--- a/README.rst
+++ b/README.rst
@@ -124,3 +124,13 @@ bson4jackson in Eclipse. Run the following command::
   ./gradlew eclipse
 
 Then import the project into your workspace.
+
+IntelliJ
+.......
+
+Gradle includes a task that creates all files required to develop
+bson4jackson in IntelliJ. Run the following command::
+
+  ./gradlew idea
+
+Then import the project into your workspace or open the root bson4jackson.ipr project file.

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'osgi'
 apply plugin: 'signing'
 apply plugin: 'java'
 apply plugin: 'eclipse'
+apply plugin: 'idea'
 
 version = '2.4.0'
 group = 'de.undercouch'

--- a/build.gradle
+++ b/build.gradle
@@ -92,10 +92,18 @@ task packageSources(type: Jar) {
 }
 
 task doIntegrationTest21(type: Test) {
+    useJUnit {
+        excludeCategories 'de.undercouch.bson4jackson.RequiresJackson_v2_3'
+    }
+
     classpath = sourceSets.test.output + sourceSets.main.output + configurations.integrationTest21
 }
 
 task doIntegrationTest22(type: Test) {
+    useJUnit {
+        excludeCategories 'de.undercouch.bson4jackson.RequiresJackson_v2_3'
+    }
+
     classpath = sourceSets.test.output + sourceSets.main.output + configurations.integrationTest22
 }
 

--- a/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
@@ -76,7 +76,7 @@ public class BsonFactory extends JsonFactory {
 
     /**
      * Constructor used when copy()ing a factory instance.
-     * <p/>
+     * <p>
      * Requires Jackson version 2.2.1 or above
      *
      * @throws java.lang.NoSuchMethodError on versions prior to 2.2.1

--- a/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
@@ -79,8 +79,10 @@ public class BsonFactory extends JsonFactory {
      * <p>
      * Requires Jackson version 2.2.1 or above
      *
-     * @throws java.lang.NoSuchMethodError on versions prior to 2.2.1
+     * @throws java.lang.NoSuchMethodError on jackson versions prior to 2.2.1
      * @see JsonFactory#JsonFactory(JsonFactory, ObjectCodec)
+     *
+     * @since 2.5
      */
     protected BsonFactory(BsonFactory src, ObjectCodec codec) {
         super(src, codec);
@@ -93,8 +95,11 @@ public class BsonFactory extends JsonFactory {
      *
      * Requires Jackson version 2.2.1 or above
      *
+     * @return deep copy of the factory
      * @throws java.lang.NoSuchMethodError on versions prior to 2.2.1
      * @see JsonFactory#copy()
+     *
+     * @since 2.5
      */
     public BsonFactory copy() {
         _checkInvalidCopy(BsonFactory.class);

--- a/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
@@ -73,6 +73,26 @@ public class BsonFactory extends JsonFactory {
     public BsonFactory(ObjectCodec oc) {
     	super(oc);
     }
+
+    /**
+     * Constructor used when copy()ing a factory instance.
+     *
+     * @since 2.2.1
+     */
+    protected BsonFactory(BsonFactory src, ObjectCodec codec) {
+        super(src, codec);
+        _bsonGeneratorFeatures = src._bsonGeneratorFeatures;
+        _bsonParserFeatures = src._bsonParserFeatures;
+    }
+
+    /**
+     * @see JsonFactory#copy()
+     */
+    public BsonFactory copy() {
+        _checkInvalidCopy(BsonFactory.class);
+        // as per above, do clear ObjectCodec
+        return new BsonFactory(this, null);
+    }
     
     /**
      * Method for enabling/disabling specified generator features

--- a/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonFactory.java
@@ -76,8 +76,11 @@ public class BsonFactory extends JsonFactory {
 
     /**
      * Constructor used when copy()ing a factory instance.
+     * <p/>
+     * Requires Jackson version 2.2.1 or above
      *
-     * @since 2.2.1
+     * @throws java.lang.NoSuchMethodError on versions prior to 2.2.1
+     * @see JsonFactory#JsonFactory(JsonFactory, ObjectCodec)
      */
     protected BsonFactory(BsonFactory src, ObjectCodec codec) {
         super(src, codec);
@@ -86,6 +89,11 @@ public class BsonFactory extends JsonFactory {
     }
 
     /**
+     * Returns a new cloned copy of the factory
+     *
+     * Requires Jackson version 2.2.1 or above
+     *
+     * @throws java.lang.NoSuchMethodError on versions prior to 2.2.1
      * @see JsonFactory#copy()
      */
     public BsonFactory copy() {
@@ -93,7 +101,7 @@ public class BsonFactory extends JsonFactory {
         // as per above, do clear ObjectCodec
         return new BsonFactory(this, null);
     }
-    
+
     /**
      * Method for enabling/disabling specified generator features
      * (check {@link BsonGenerator.Feature} for list of features)
@@ -173,12 +181,12 @@ public class BsonFactory extends JsonFactory {
 	public final boolean isEnabled(BsonParser.Feature f) {
 		return (_bsonParserFeatures & f.getMask()) != 0;
 	}
-	
+
 	@Override
 	protected BsonGenerator _createGenerator(Writer out, IOContext ctxt) {
 		throw new UnsupportedOperationException("Can not create writer for non-byte-based target");
 	}
-	
+
 	/**
 	 * @deprecated Removed in Jackson 2.4
 	 */
@@ -186,7 +194,7 @@ public class BsonFactory extends JsonFactory {
 	protected BsonGenerator _createJsonGenerator(Writer out, IOContext ctxt) {
 		return _createGenerator(out, ctxt);
 	}
-	
+
 	/**
 	 * @deprecated Removed in Jackson 2.4
 	 */
@@ -194,7 +202,7 @@ public class BsonFactory extends JsonFactory {
 	protected BsonParser _createJsonParser(byte[] data, int offset, int len, IOContext ctxt) {
         return _createParser(data, offset, len, ctxt);
     }
-	
+
 	/**
 	 * @deprecated Removed in Jackson 2.4
 	 */
@@ -202,7 +210,7 @@ public class BsonFactory extends JsonFactory {
 	protected BsonParser _createJsonParser(InputStream in, IOContext ctxt) {
         return _createParser(in, ctxt);
     }
-	
+
 	/**
 	 * @deprecated Removed in Jackson 2.4
 	 */
@@ -210,12 +218,12 @@ public class BsonFactory extends JsonFactory {
 	protected BsonParser _createJsonParser(Reader r, IOContext ctxt) {
         return _createParser(r, ctxt);
     }
-	
+
 	@Override
 	protected BsonParser _createParser(byte[] data, int offset, int len, IOContext ctxt) {
 		return _createParser(new UnsafeByteArrayInputStream(data, offset, len), ctxt);
 	}
-	
+
 	@Override
 	protected BsonParser _createParser(InputStream in, IOContext ctxt) {
 		BsonParser p = new BsonParser(ctxt, _parserFeatures, _bsonParserFeatures, in);
@@ -225,17 +233,17 @@ public class BsonFactory extends JsonFactory {
 		}
 		return p;
 	}
-	
+
 	@Override
 	protected BsonParser _createParser(Reader r, IOContext ctxt) {
 		throw new UnsupportedOperationException("Can not create reader for non-byte-based source");
 	}
-	
+
 	@Override
 	protected BsonGenerator _createUTF8Generator(OutputStream out, IOContext ctxt) throws IOException {
 		return createGenerator(out);
 	}
-	
+
 	/**
 	 * @deprecated Removed in Jackson 2.4
 	 */
@@ -243,13 +251,13 @@ public class BsonFactory extends JsonFactory {
 	protected BsonGenerator _createUTF8JsonGenerator(OutputStream out, IOContext ctxt) throws IOException {
 		return _createUTF8Generator(out, ctxt);
 	}
-	
+
 	@Override
 	protected Writer _createWriter(OutputStream out, JsonEncoding enc, IOContext ctxt)
 			throws IOException {
 		throw new UnsupportedOperationException("Can not create generator for non-byte-based target");
 	}
-	
+
 	@Override
 	public BsonGenerator createGenerator(File f, JsonEncoding enc) throws IOException {
 		OutputStream out = new FileOutputStream(f);
@@ -260,12 +268,12 @@ public class BsonFactory extends JsonFactory {
 		}
 		return createGenerator(out, enc);
 	}
-	
+
 	@Override
 	public BsonGenerator createGenerator(OutputStream out) throws IOException {
 		return createGenerator(out, JsonEncoding.UTF8);
 	}
-	
+
 	@Override
 	public BsonGenerator createGenerator(OutputStream out, JsonEncoding enc) throws IOException {
 		IOContext ctxt = _createContext(out, true);
@@ -280,66 +288,66 @@ public class BsonFactory extends JsonFactory {
     	}
     	return g;
 	}
-	
+
 	@Override
 	public BsonGenerator createGenerator(Writer writer) {
 		throw new UnsupportedOperationException("Can not create generator for non-byte-based target");
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonGenerator createJsonGenerator(File f, JsonEncoding enc) throws IOException {
 		return createGenerator(f, enc);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonGenerator createJsonGenerator(OutputStream out) throws IOException {
 		return createGenerator(out);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonGenerator createJsonGenerator(OutputStream out, JsonEncoding enc) throws IOException {
 		return createGenerator(out, enc);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonGenerator createJsonGenerator(Writer out) {
 		return createGenerator(out);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(byte[] data) throws IOException {
 		return createParser(data);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(byte[] data, int offset, int len) throws IOException {
 		return createParser(data, offset, len);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(File f) throws IOException {
 		return createParser(f);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(InputStream in) throws IOException {
 		return createParser(in);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(Reader r) {
 		return createParser(r);
 	}
-	
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public BsonParser createJsonParser(String content) {
@@ -351,7 +359,7 @@ public class BsonFactory extends JsonFactory {
 	public BsonParser createJsonParser(URL url) throws IOException {
 		return createParser(url);
 	}
-	
+
 	@Override
 	public BsonParser createParser(byte[] data) throws IOException {
 		IOContext ctxt = _createContext(data, true);
@@ -363,7 +371,7 @@ public class BsonFactory extends JsonFactory {
         }
         return _createParser(data, 0, data.length, ctxt);
 	}
-	
+
 	@Override
 	public BsonParser createParser(byte[] data, int offset, int len) throws IOException {
 		IOContext ctxt = _createContext(data, true);
@@ -375,7 +383,7 @@ public class BsonFactory extends JsonFactory {
         }
         return _createParser(data, offset, len, ctxt);
 	}
-	
+
 	@SuppressWarnings("resource")
 	@Override
 	public BsonParser createParser(File f) throws IOException {
@@ -386,7 +394,7 @@ public class BsonFactory extends JsonFactory {
         }
         return _createParser(in, ctxt);
     }
-	
+
 	@Override
 	public BsonParser createParser(InputStream in) throws IOException {
         IOContext ctxt = _createContext(in, false);
@@ -395,17 +403,17 @@ public class BsonFactory extends JsonFactory {
         }
         return _createParser(in, ctxt);
     }
-	
+
 	@Override
 	public BsonParser createParser(Reader r) {
 		throw new UnsupportedOperationException("Can not create reader for non-byte-based source");
 	}
-	
+
 	@Override
 	public BsonParser createParser(String content) {
 		throw new UnsupportedOperationException("Can not create reader for non-byte-based source");
 	}
-	
+
 	@Override
 	public BsonParser createParser(URL url) throws IOException {
         IOContext ctxt = _createContext(url, true);

--- a/src/test/java/de/undercouch/bson4jackson/BsonFactoryTest.java
+++ b/src/test/java/de/undercouch/bson4jackson/BsonFactoryTest.java
@@ -1,3 +1,17 @@
+// Copyright 2010-2011 Michel Kraemer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package de.undercouch.bson4jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;

--- a/src/test/java/de/undercouch/bson4jackson/BsonFactoryTest.java
+++ b/src/test/java/de/undercouch/bson4jackson/BsonFactoryTest.java
@@ -1,0 +1,57 @@
+package de.undercouch.bson4jackson;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests {@link BsonFactory}
+ * @author Andy Coates
+ */
+public class BsonFactoryTest {
+    private BsonFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new BsonFactory();
+    }
+
+    @Test
+    public void shouldCreateNewInstanceOnCopy() throws Exception {
+        final BsonFactory copy = factory.copy();
+
+        assertNotSame(factory, copy);
+    }
+
+    @Test
+    public void shouldCopyParserFeaturesOnCopy() throws Exception {
+        final BsonParser.Feature feature = BsonParser.Feature.HONOR_DOCUMENT_LENGTH;
+        factory.configure(feature, !factory.isEnabled(feature));
+
+        final BsonFactory copy = factory.copy();
+
+        assertEquals(factory.isEnabled(feature), copy.isEnabled(feature));
+    }
+
+    @Test
+    public void shouldCopyGeneratorFeaturesOnCopy() throws Exception {
+        final BsonGenerator.Feature feature = BsonGenerator.Feature.ENABLE_STREAMING;
+        factory.configure(feature, !factory.isEnabled(feature));
+
+        final BsonFactory copy = factory.copy();
+
+        assertEquals(factory.isEnabled(feature), copy.isEnabled(feature));
+    }
+
+    @Test
+    public void shouldCopySuperClass() throws Exception {
+        final JsonFactory.Feature feature = JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
+        factory.configure(feature, !factory.isEnabled(feature));
+
+        final BsonFactory copy = factory.copy();
+
+        assertEquals(factory.isEnabled(feature), copy.isEnabled(feature));
+    }
+}

--- a/src/test/java/de/undercouch/bson4jackson/BsonFactoryTest.java
+++ b/src/test/java/de/undercouch/bson4jackson/BsonFactoryTest.java
@@ -3,6 +3,7 @@ package de.undercouch.bson4jackson;
 import com.fasterxml.jackson.core.JsonFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.*;
 
@@ -19,6 +20,7 @@ public class BsonFactoryTest {
     }
 
     @Test
+    @Category(value = RequiresJackson_v2_3.class)
     public void shouldCreateNewInstanceOnCopy() throws Exception {
         final BsonFactory copy = factory.copy();
 
@@ -26,6 +28,7 @@ public class BsonFactoryTest {
     }
 
     @Test
+    @Category(value = RequiresJackson_v2_3.class)
     public void shouldCopyParserFeaturesOnCopy() throws Exception {
         final BsonParser.Feature feature = BsonParser.Feature.HONOR_DOCUMENT_LENGTH;
         factory.configure(feature, !factory.isEnabled(feature));
@@ -36,6 +39,7 @@ public class BsonFactoryTest {
     }
 
     @Test
+    @Category(value = RequiresJackson_v2_3.class)
     public void shouldCopyGeneratorFeaturesOnCopy() throws Exception {
         final BsonGenerator.Feature feature = BsonGenerator.Feature.ENABLE_STREAMING;
         factory.configure(feature, !factory.isEnabled(feature));
@@ -46,6 +50,7 @@ public class BsonFactoryTest {
     }
 
     @Test
+    @Category(value = RequiresJackson_v2_3.class)
     public void shouldCopySuperClass() throws Exception {
         final JsonFactory.Feature feature = JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
         factory.configure(feature, !factory.isEnabled(feature));

--- a/src/test/java/de/undercouch/bson4jackson/RequiresJackson_v2_3.java
+++ b/src/test/java/de/undercouch/bson4jackson/RequiresJackson_v2_3.java
@@ -1,9 +1,23 @@
+// Copyright 2010-2011 Michel Kraemer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package de.undercouch.bson4jackson;
 
 /**
  * Test classification interface to use with JUnit categories
  *
- * @author datalorax - 04/03/2015.
+ * @author Andy Coates - 04/03/2015.
  */
 public interface RequiresJackson_v2_3 {
 }

--- a/src/test/java/de/undercouch/bson4jackson/RequiresJackson_v2_3.java
+++ b/src/test/java/de/undercouch/bson4jackson/RequiresJackson_v2_3.java
@@ -1,0 +1,9 @@
+package de.undercouch.bson4jackson;
+
+/**
+ * Test classification interface to use with JUnit categories
+ *
+ * @author datalorax - 04/03/2015.
+ */
+public interface RequiresJackson_v2_3 {
+}


### PR DESCRIPTION
#44 Resolved - added support for copy() method on BsonFactory to allow cloning of ObjectMappers using BsonFactory instances.