### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/BsonGenerator.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonGenerator.java
@@ -79,7 +79,7 @@ public class BsonGenerator extends GeneratorBase {
 		 * @return the bit mask that identifies this feature
 		 */
 		public int getMask() {
-			return (1 << ordinal());
+			return 1 << ordinal();
 		}
 	}
 	
@@ -116,7 +116,7 @@ public class BsonGenerator extends GeneratorBase {
 		public DocumentInfo(DocumentInfo parent, int headerPos, boolean array) {
 			this.parent = parent;
 			this.headerPos = headerPos;
-			this.currentArrayPos = (array ? 0 : -1);
+			this.currentArrayPos = array ? 0 : -1;
 		}
 	}
 	
@@ -215,7 +215,7 @@ public class BsonGenerator extends GeneratorBase {
 	 * @return true if the generator is currently processing an array
 	 */
 	protected boolean isArray() {
-		return (_currentDocument == null ? false : _currentDocument.currentArrayPos >= 0);
+		return _currentDocument == null ? false : _currentDocument.currentArrayPos >= 0;
 	}
 	
 	/**
@@ -323,8 +323,8 @@ public class BsonGenerator extends GeneratorBase {
 		_writeArrayFieldNameIfNeeded();
 		if (_currentDocument != null) {
 			//embedded document/array
-			_buffer.putByte(_typeMarker, (array ? BsonConstants.TYPE_ARRAY :
-				BsonConstants.TYPE_DOCUMENT));
+			_buffer.putByte(_typeMarker, array ? BsonConstants.TYPE_ARRAY :
+				BsonConstants.TYPE_DOCUMENT);
 		}
 		_currentDocument = new DocumentInfo(_currentDocument, _buffer.size(), array);
 		reserveHeader();

--- a/src/main/java/de/undercouch/bson4jackson/BsonParser.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonParser.java
@@ -69,7 +69,7 @@ public class BsonParser extends ParserBase {
 		 * @return the bit mask that identifies this feature
 		 */
 		public int getMask() {
-			return (1 << ordinal());
+			return 1 << ordinal();
 		}
 	}
 
@@ -261,7 +261,7 @@ public class BsonParser extends ParserBase {
 					ctx.type = _in.readByte();
 					if (ctx.type == BsonConstants.TYPE_END) {
 						//end of document
-						_currToken = (ctx.array ? JsonToken.END_ARRAY : JsonToken.END_OBJECT);
+						_currToken = ctx.array ? JsonToken.END_ARRAY : JsonToken.END_OBJECT;
 						_currentContext = _currentContext.parent;
 					} else if (ctx.type == BsonConstants.TYPE_UNDEFINED) {
 						//skip field name and then ignore this token
@@ -318,7 +318,7 @@ public class BsonParser extends ParserBase {
 				case BsonConstants.TYPE_BOOLEAN:
 					boolean b = _in.readBoolean();
 					ctx.value = b;
-					_currToken = (b ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE);
+					_currToken = b ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE;
 					break;
 					
 				case BsonConstants.TYPE_DATETIME:
@@ -426,7 +426,7 @@ public class BsonParser extends ParserBase {
 		}
 
 		_currentContext = new Context(_currentContext, array);
-		return (array ? JsonToken.START_ARRAY : JsonToken.START_OBJECT);
+		return array ? JsonToken.START_ARRAY : JsonToken.START_OBJECT;
 	}
 	
 	/**
@@ -792,7 +792,7 @@ public class BsonParser extends ParserBase {
 	
 	@Override
 	public Object getEmbeddedObject() throws IOException, JsonParseException {
-		return (_currentContext != null ? _currentContext.value : null);
+		return _currentContext != null ? _currentContext.value : null;
 	}
 
 	@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava