### PR TITLE
Multiple code improvements - squid:UselessParenthesesCheck, squid:S1197

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/io/CountingInputStream.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/CountingInputStream.java
@@ -58,7 +58,7 @@ public class CountingInputStream extends FilterInputStream {
 	}
 	
 	@Override
-	public int read(byte b[]) throws IOException {
+	public int read(byte[] b) throws IOException {
 		int r = super.read(b);
 		if (r > 0) {
 			_pos += r;
@@ -67,7 +67,7 @@ public class CountingInputStream extends FilterInputStream {
 	}
 	
 	@Override
-	public int read(byte b[], int off, int len) throws IOException {
+	public int read(byte[] b, int off, int len) throws IOException {
 		int r = super.read(b, off, len);
 		if (r > 0) {
 			_pos += r;

--- a/src/main/java/de/undercouch/bson4jackson/io/StaticBufferedInputStream.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/StaticBufferedInputStream.java
@@ -127,7 +127,7 @@ public class StaticBufferedInputStream extends InputStream {
 	}
 	
 	@Override
-	public int read(byte b[], int off, int len) throws IOException {
+	public int read(byte[] b, int off, int len) throws IOException {
 		if (len == 0) {
 			return 0;
 		}

--- a/src/main/java/de/undercouch/bson4jackson/io/UnsafeByteArrayInputStream.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/UnsafeByteArrayInputStream.java
@@ -65,7 +65,7 @@ public class UnsafeByteArrayInputStream extends InputStream {
 	
 	@Override
 	public int read() {
-		return (_pos >= _count ? -1 : _buf[_pos++]);
+		return _pos >= _count ? -1 : _buf[_pos++];
 	}
 	
 	@Override
@@ -75,7 +75,7 @@ public class UnsafeByteArrayInputStream extends InputStream {
 		}
 		
 		int avail = _count - _pos;
-		int cnt = (len < avail ? len : avail);
+		int cnt = len < avail ? len : avail;
 		System.arraycopy(_buf, _pos, b, off, cnt);
 		_pos += cnt;
 		return cnt;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
George Kankava