### PR TITLE
BsonGenerator.java: Fix flush() not flushing buffer

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/BsonGenerator.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonGenerator.java
@@ -251,6 +251,8 @@ public class BsonGenerator extends GeneratorBase {
 	
 	@Override
 	public void flush() throws IOException {
+		_buffer.writeTo(_out);
+        _buffer.clear();
 		_out.flush();
 	}
 

--- a/src/test/java/de/undercouch/bson4jackson/BsonGeneratorTest.java
+++ b/src/test/java/de/undercouch/bson4jackson/BsonGeneratorTest.java
@@ -38,6 +38,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.databind.*;
 import org.bson.BSONDecoder;
 import org.bson.BSONObject;
 import org.bson.BasicBSONDecoder;
@@ -50,8 +51,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.core.io.SerializedString;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.undercouch.bson4jackson.io.DynamicOutputBuffer;
 import de.undercouch.bson4jackson.types.JavaScript;
@@ -444,7 +443,71 @@ public class BsonGeneratorTest {
 		byte[] objbin = (byte[])obj.get("binary");
 		assertArrayEquals(binary, objbin);
 	}
-	
+
+
+    /** Simple dummy object for testing object (de-)serialization. */
+    private static class TestPojo
+    {
+        public Integer i;
+        public String s;
+    }
+
+
+	@Test
+	public void writeMultipleObjects() throws Exception {
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		BsonFactory bsonFactory = new BsonFactory();
+
+		// test input 1
+        TestPojo testObjectIn1 = new TestPojo();
+        testObjectIn1.i = 42;
+        testObjectIn1.s = "43";
+
+        // test input 2
+        TestPojo testObjectIn2 = new TestPojo();
+        testObjectIn2.i = 44;
+        testObjectIn2.s = "45";
+
+		// write in non-streaming mode using explicit flush()
+		// we explicitly create a sequence writer for writing out several TestPojo objects in a row
+		// (useful for storage/online communications)
+		bsonFactory.disable(BsonGenerator.Feature.ENABLE_STREAMING);
+		ObjectMapper mapperExplicit = new ObjectMapper(bsonFactory);
+		mapperExplicit.disable(SerializationFeature.FLUSH_AFTER_WRITE_VALUE);
+        ObjectWriter objectWriterExplicit = mapperExplicit.writer();   // use writerFor(TestPojo.class) in Jackson 2.5+
+        SequenceWriter sequenceWriterExplicit = objectWriterExplicit.writeValues(outputStream);
+        sequenceWriterExplicit.write(testObjectIn1);
+        sequenceWriterExplicit.flush();
+
+		// were all bytes associated with our top-level object testObjectIn1
+		// successfully written to the output stream?
+        TestPojo testObjectOut1 = mapperExplicit.readValue(outputStream.toByteArray(), TestPojo.class);
+        assertEquals(testObjectOut1.i, testObjectIn1.i);
+        assertEquals(testObjectOut1.s, testObjectIn1.s);
+
+        sequenceWriterExplicit.close();
+
+		// clear buffer
+		outputStream.reset();
+
+		// write() with implicit flush() (streaming mode)
+		bsonFactory.enable(BsonGenerator.Feature.ENABLE_STREAMING);
+		ObjectMapper mapperImplicit = new ObjectMapper(bsonFactory);
+		mapperImplicit.enable(SerializationFeature.FLUSH_AFTER_WRITE_VALUE);
+		ObjectWriter objectWriterImplicit = mapperImplicit.writer();   // use writerFor(TestPojo.class) in Jackson 2.5+
+        SequenceWriter sequenceWriterImplicit = objectWriterImplicit.writeValues(outputStream);
+        sequenceWriterImplicit.write(testObjectIn2);
+
+		// second object also passed through?
+        TestPojo testObjectOut2 = mapperImplicit.readValue(outputStream.toByteArray(), TestPojo.class);
+		assertEquals(testObjectOut2.i, testObjectIn2.i);
+        assertEquals(testObjectOut2.s, testObjectIn2.s);
+
+        sequenceWriterImplicit.close();
+	}
+
+
 	@Test
 	public void characterEscapes() throws Exception {
 		JsonNode node = new ObjectMapper().readTree(


### PR DESCRIPTION
I encountered an issue when using ObjectMapper.readValues(). It seems like BsonGenerator doesn't correctly implement BaseGenerator.flush().

The is also an open issue ( https://github.com/michel-kraemer/bson4jackson/issues/62 ) by user kurbatov ( https://github.com/kurbatov ) that could be related.

The changed version has been tested successfully (using test suite and real world scenario) with Jackson 2.7.3 on Android 5.1.1.