### PR TITLE
Overrided toString and added toByteArray method for ObjectID similar to org.bson.ObjectId

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/BsonGenerator.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonGenerator.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
-import de.undercouch.bson4jackson.io.ByteOrderUtil;
 import de.undercouch.bson4jackson.io.DynamicOutputBuffer;
 import de.undercouch.bson4jackson.types.JavaScript;
 import de.undercouch.bson4jackson.types.ObjectId;
@@ -242,7 +241,7 @@ public class BsonGenerator extends GeneratorBase {
 	
 	/**
 	 * Writes the BSON document header to the output buffer at the
-	 * given position. Does not increase the buffer's write position. 
+	 * given position. Does not increase the buffer's write position.
 	 * @param pos the position where to write the header
 	 */
 	protected void putHeader(int pos) {
@@ -616,7 +615,7 @@ public class BsonGenerator extends GeneratorBase {
 		//write string size
 		_buffer.putInt(p, length);
 		
-		flushBuffer();		
+		flushBuffer();
 	}
 
 	@Override
@@ -649,13 +648,7 @@ public class BsonGenerator extends GeneratorBase {
 		_writeArrayFieldNameIfNeeded();
 		_verifyValueWrite("write datetime");
 		_buffer.putByte(_typeMarker, BsonConstants.TYPE_OBJECTID);
-		// ObjectIds have their byte order flipped
-		int time = ByteOrderUtil.flip(objectId.getTime());
-		int machine = ByteOrderUtil.flip(objectId.getMachine());
-		int inc = ByteOrderUtil.flip(objectId.getInc());
-		_buffer.putInt(time);
-		_buffer.putInt(machine);
-		_buffer.putInt(inc);
+		_buffer.putBytes(objectId.toByteArray());
 		flushBuffer();
 	}
 
@@ -785,7 +778,7 @@ public class BsonGenerator extends GeneratorBase {
 	 *
 	 * @param string The string to write
 	 * @return The number of bytes written, including the terminating null byte
-	 * @throws IOException If an error occurred in the stream while writing 
+	 * @throws IOException If an error occurred in the stream while writing
 	 */
 	protected int _writeCString(String string) throws IOException {
 		//escape characters if necessary

--- a/src/main/java/de/undercouch/bson4jackson/io/ByteOrderUtil.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/ByteOrderUtil.java
@@ -16,20 +16,44 @@ package de.undercouch.bson4jackson.io;
 
 /**
  * Provides static methods to change the byte order of single values
+ *
  * @author Michel Kraemer
  */
 public class ByteOrderUtil {
-	/**
-	 * Flips the byte order of an integer
-	 * @param i the integer
-	 * @return the flipped integer
-	 */
-	public static int flip(int i) {
-		int result = 0;
-		result |= (i & 0xFF) << 24;
-		result |= (i & 0xFF00) << 8;
-		result |= ((i & 0xFF0000) >> 8) & 0xFF00;
-		result |= ((i & 0xFF000000) >> 24) & 0xFF;
-		return result;
-	}
+    /**
+     * Flips the byte order of an integer
+     *
+     * @param i the integer
+     * @return the flipped integer
+     */
+    public static int flip(int i) {
+        return makeInt(int0(i), int1(i), int2(i), int3(i));
+    }
+
+    public static byte[] reverseByteArray(int i) {
+        return new byte[]{int3(i), int2(i), int1(i), int0(i)};
+    }
+
+    private static int makeInt(final byte b3, final byte b2, final byte b1, final byte b0) {
+        return (((b3) << 24)
+                | ((b2 & 0xff) << 16)
+                | ((b1 & 0xff) << 8)
+                | ((b0 & 0xff)));
+    }
+
+    private static byte int3(final int x) {
+        return (byte) (x >> 24);
+    }
+
+    private static byte int2(final int x) {
+        return (byte) (x >> 16);
+    }
+
+    private static byte int1(final int x) {
+        return (byte) (x >> 8);
+    }
+
+    private static byte int0(final int x) {
+        return (byte) (x);
+    }
 }

--- a/src/main/java/de/undercouch/bson4jackson/types/ObjectId.java
+++ b/src/main/java/de/undercouch/bson4jackson/types/ObjectId.java
@@ -14,12 +14,19 @@
 
 package de.undercouch.bson4jackson.types;
 
+import de.undercouch.bson4jackson.io.ByteOrderUtil;
+
 /**
  * A unique identifier for MongoDB documents. Such identifiers
  * consist of a timestamp, a machine ID and a counter.
+ *
  * @author Michel Kraemer
  */
 public class ObjectId {
+	private static final char[] HEX_CHARS = new char[]{
+			'0', '1', '2', '3', '4', '5', '6', '7',
+			'8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
 	/**
 	 * The timestamp
 	 */
@@ -66,5 +73,36 @@ public class ObjectId {
 	 */
 	public int getInc() {
 		return _inc;
+	}
+
+	@Override
+	public String toString() {
+		char[] chars = new char[24];
+		int i = 0;
+		for (byte b : toByteArray()) {
+			chars[i++] = HEX_CHARS[b >> 4 & 0xF];
+			chars[i++] = HEX_CHARS[b & 0xF];
+		}
+		return new String(chars);
+	}
+
+	public byte[] toByteArray() {
+		byte[] bytes = new byte[12];
+		byte[] timeBytes = ByteOrderUtil.reverseByteArray(_time);
+		byte[] machineBytes = ByteOrderUtil.reverseByteArray(_machine);
+		byte[] incBytes = ByteOrderUtil.reverseByteArray(_inc);
+		bytes[0] = timeBytes[0];
+		bytes[1] = timeBytes[1];
+		bytes[2] = timeBytes[2];
+		bytes[3] = timeBytes[3];
+		bytes[4] = machineBytes[0];
+		bytes[5] = machineBytes[1];
+		bytes[6] = machineBytes[2];
+		bytes[7] = machineBytes[3];
+		bytes[8] = incBytes[0];
+		bytes[9] = incBytes[1];
+		bytes[10] = incBytes[2];
+		bytes[11] = incBytes[3];
+		return bytes;
 	}
 }


### PR DESCRIPTION
Existing `ObjectId` implementation is outdated and should be updated to follow Mongo 3.0 format.
That means `ObjectId` should be stored as array of bytes. As a first step I propose to implement `toByteArray` method from original `org.bson.ObjectId`
