### PR TITLE
fixing bug causing infinite loop in some situations

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/io/DynamicOutputBuffer.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/DynamicOutputBuffer.java
@@ -254,7 +254,7 @@ public class DynamicOutputBuffer {
 	 * @return the buffer at the requested position
 	 */
 	protected ByteBuffer getBuffer(int position) {
-		int n = position/ _bufferSize;
+		int n = position / _bufferSize;
 		while (n >= _buffers.size()) {
 			addNewBuffer();
 		}

--- a/src/main/java/de/undercouch/bson4jackson/io/DynamicOutputBuffer.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/DynamicOutputBuffer.java
@@ -254,7 +254,7 @@ public class DynamicOutputBuffer {
 	 * @return the buffer at the requested position
 	 */
 	protected ByteBuffer getBuffer(int position) {
-		int n = position / _bufferSize;
+		int n = (position + 4) / _bufferSize;
 		while (n >= _buffers.size()) {
 			addNewBuffer();
 		}
@@ -570,7 +570,7 @@ public class DynamicOutputBuffer {
 					if (minibb == null) {
 						minibb = ByteBuffer.allocate(4);
 					}
-					minibb.rewind();
+					minibb.clear(); //rewind();
 					bb = minibb;
 					index = 0;
 				} else {

--- a/src/main/java/de/undercouch/bson4jackson/io/DynamicOutputBuffer.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/DynamicOutputBuffer.java
@@ -254,7 +254,7 @@ public class DynamicOutputBuffer {
 	 * @return the buffer at the requested position
 	 */
 	protected ByteBuffer getBuffer(int position) {
-		int n = (position + 4) / _bufferSize;
+		int n = position/ _bufferSize;
 		while (n >= _buffers.size()) {
 			addNewBuffer();
 		}


### PR DESCRIPTION
I'm not sure whether both of these changes are needed or perhaps `minibb.clear(); //rewind();` will be enough but it should not hurt. The problem was that when OVERFLOW happens at the time when index  is 1 bytes less than capacity of the current buffer the code never allocates new buffer and keeps on looping without making any progress. 

The problem with minimum.rewind() is that limit of the small buffer can be 1 byte before rewind (set by encoder) and rewind makes buffer capacity 1 byte. So, when index is close to its limit and small buffer capacity is 1 byte there is never enough memory to store a 3 byte utf-8 encoded char which is what we see. 