### PR TITLE
Improve serialization performance by using bulk api for binary type.

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/BsonGenerator.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonGenerator.java
@@ -494,10 +494,7 @@ public class BsonGenerator extends GeneratorBase {
         if (end > data.length) {
             end = data.length;
         }
-        while (offset < end) {
-            _buffer.putByte(data[offset]);
-            ++offset;
-        }
+        _buffer.putBytes(data, offset, end);
         flushBuffer();
     }
 

--- a/src/main/java/de/undercouch/bson4jackson/io/DynamicOutputBuffer.java
+++ b/src/main/java/de/undercouch/bson4jackson/io/DynamicOutputBuffer.java
@@ -327,6 +327,18 @@ public class DynamicOutputBuffer {
     }
 
     /**
+     * Puts bytes array into the buffer at the given position with given offset.
+     * Does not increase the write position.
+     * @param bs an array of bytes to put
+     * @param offset the offset within the array of the first byte to be read
+     * @param length the number of bytes to be read from the given array
+     */
+    public void putBytes(byte[] bs, int offset, int length) {
+        putBytes(_position, bs, offset, length);
+        _position += length;
+    }
+
+    /**
      * Puts a byte into the buffer at the given position. Does
      * not increase the write position.
      * @param pos the position where to put the byte
@@ -346,17 +358,29 @@ public class DynamicOutputBuffer {
      * @param bs an array of bytes to put
      */
     public void putBytes(int pos, byte... bs) {
-        adaptSize(pos + bs.length);
-        ByteBuffer bb = null;
-        int i = _bufferSize;
-        for (byte b : bs) {
-            if (i == _bufferSize) {
-                bb = getBuffer(pos);
-                i = pos % _bufferSize;
-            }
-            bb.put(i, b);
-            ++i;
-            ++pos;
+        putBytes(pos, bs, 0, bs.length);
+    }
+
+    /**
+     * Puts bytes array into the buffer at the given position with given offset.
+     * Does not increase the write position.
+     * @param pos the position where to put the bytes
+     * @param bs an array of bytes to put
+     * @param offset the offset within the array of the first byte to be read
+     * @param length the number of bytes to be read from the given array
+     */
+    public void putBytes(int pos, byte[] bs, int offset, int length) {
+        adaptSize(pos + length);
+        ByteBuffer bb;
+        while (length > 0) {
+            bb = getBuffer(pos);
+            int index = pos % _bufferSize;
+            bb.position(index);
+            int chunkLength = Math.min(bb.limit() - index, length);
+            bb.put(bs, offset, chunkLength);
+            pos += chunkLength;
+            offset += chunkLength;
+            length -= chunkLength;
         }
     }
 


### PR DESCRIPTION
Hi, I wanted to use this library in one of my projects and had had same problem as desribed in #97.

This patch contains my naive implementation of bulk api for binary types.

My simple tests show that large documents serialization now much faster (up to 10 times).

I'm not sure about new public api method in `DynamicOutputBuffer` I've added, should it stays like this?

P.S. Thanks for a great project! :^)

Fixes #97