### PR TITLE
Ensures that _currToken is set to null if it has been returned from nextToken()

### DIFF
--- a/src/main/java/de/undercouch/bson4jackson/BsonParser.java
+++ b/src/main/java/de/undercouch/bson4jackson/BsonParser.java
@@ -228,7 +228,7 @@ public class BsonParser extends ParserBase {
             if (ctx == null) {
                 if (_currToken == JsonToken.END_OBJECT) {
                     // end of input
-                    return null;
+                    return (_currToken = null);
                 }
                 throw new JsonParseException("Found element outside the document",
                         getTokenLocation());

--- a/src/test/java/de/undercouch/bson4jackson/BsonParserTest.java
+++ b/src/test/java/de/undercouch/bson4jackson/BsonParserTest.java
@@ -691,4 +691,22 @@ public class BsonParserTest {
 
         assertEquals(clone.inner.floatValue, outer.inner.floatValue, 0);
     }
+
+    /**
+     * Parse empty object, specifically checking getCurrentToken() along the way. See issue #128
+     * @throws Exception if something goes wrong
+     */
+    @Test
+    public void parseEmptyObject() throws Exception {
+        byte[] emptyBsonBytes = new BasicBSONEncoder().encode(new BasicBSONObject());
+        try (BsonParser dec = new BsonFactory().createJsonParser(emptyBsonBytes)) {
+            assertNull(dec.getCurrentToken());
+            assertEquals(JsonToken.START_OBJECT, dec.nextToken());
+            assertEquals(JsonToken.START_OBJECT, dec.getCurrentToken());
+            assertEquals(JsonToken.END_OBJECT, dec.nextToken());
+            assertEquals(JsonToken.END_OBJECT, dec.getCurrentToken());
+            assertNull(dec.nextToken());
+            assertNull(dec.getCurrentToken());
+        }
+    }
 }


### PR DESCRIPTION
Fixes #128